### PR TITLE
Add aws credential profile to s3 state configuration

### DIFF
--- a/lib/tfoutputs/configurator/backends/s3_state_configuration.rb
+++ b/lib/tfoutputs/configurator/backends/s3_state_configuration.rb
@@ -19,7 +19,7 @@ module TfOutputs
           # Setup the base client config which must always have a bucket region
           client_config = {region: @bucket_region}
           # if a profile was supplied, then add that to the client config
-          if @profile != nil
+          if !@profile.nil?
             client_config[:profile] = @profile
           end
 

--- a/lib/tfoutputs/configurator/backends/s3_state_configuration.rb
+++ b/lib/tfoutputs/configurator/backends/s3_state_configuration.rb
@@ -10,12 +10,21 @@ module TfOutputs
           @bucket_name = options[:bucket_name]
           @bucket_key = options[:bucket_key]
           @bucket_region = options[:bucket_region]
-          @profile = options[:profile]
+          @profile = options[:profile] ? options[:profile] : nil
         end
 
         def save
           file = Tempfile.new('tf_state')
-          s3 = Aws::S3::Client.new(region: @bucket_region, profile: @profile)
+
+          # Setup the base client config which must always have a bucket region
+          client_config = {region: @bucket_region}
+          # if a profile was supplied, then add that to the client config
+          if @profile != nil
+            client_config[:profile] = @profile
+          end
+
+          # setup s3 client
+          s3 = Aws::S3::Client.new(client_config)
           resp = s3.get_object bucket: @bucket_name, key: @bucket_key
           file.write(resp.body.string)
           file.rewind

--- a/lib/tfoutputs/configurator/backends/s3_state_configuration.rb
+++ b/lib/tfoutputs/configurator/backends/s3_state_configuration.rb
@@ -10,11 +10,12 @@ module TfOutputs
           @bucket_name = options[:bucket_name]
           @bucket_key = options[:bucket_key]
           @bucket_region = options[:bucket_region]
+          @profile = options[:profile]
         end
 
         def save
           file = Tempfile.new('tf_state')
-          s3 = Aws::S3::Client.new(region: @bucket_region)
+          s3 = Aws::S3::Client.new(region: @bucket_region, profile: @profile)
           resp = s3.get_object bucket: @bucket_name, key: @bucket_key
           file.write(resp.body.string)
           file.rewind


### PR DESCRIPTION
It can be common for people to have to manage multiple aws accounts and being able to specify which aws credential profile when using this gem is necessary for them.

I haven't tested this out, this is more of a pseudocode suggestion as to what might need to happen.  I'm not well versed in how I can run my own fork of this gem in my environment, going to try that out.

I think there is more work to do here as far as making sure that profile is not a required option and such, but I wanted to submit this PR to get the conversation started.